### PR TITLE
Convert DOCKER to GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,47 @@
+name: DOCKER
+on:
+  workflow_dispatch:
+env:
+#   # This item has no matching transformer
+#   DOCKER_PAT:
+  IMAGE_NAME: tharun12/my-custom-image
+  TAG: latest
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+      with:
+        repository: tharun451/java-web-app-docker
+    - name: sh
+      shell: bash
+      run: pwd && ls -la
+    - name: sh
+      shell: bash
+      run: mvn -Dmaven.test.failure.ignore=true clean package
+  Docker_Login:
+    name: Docker Login
+    runs-on: ubuntu-latest
+    needs: Build
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: sh
+      shell: bash
+      run: '"echo $DOCKER_PAT | docker login -u tharun12 --password-stdin"'
+  Build_Docker_Image:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    needs: Docker_Login
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: sh
+      shell: bash
+      run: |-
+        docker build -t tharun12/my-custom-image .
+                        docker tag tharun12/my-custom-image tharun12/my-custom-image:version1
+                        docker push $IMAGE_NAME:$TAG


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://10.138.77.128:8082/job/DOCKER/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### DOCKER
- [ ] Ensure build tool is available: `maven`